### PR TITLE
Fix inventory add and view

### DIFF
--- a/src/components/AddProduct.tsx
+++ b/src/components/AddProduct.tsx
@@ -350,7 +350,8 @@ const AddProduct: React.FC = () => {
       formDataToSend.append('category', formData.category);
       formDataToSend.append('sport', formData.sport);
       formDataToSend.append('price', formData.price);
-      formDataToSend.append('inventory_count', formData.stock);
+      // Backend expects the quantity field for inventory count
+      formDataToSend.append('quantity', formData.stock);
       formDataToSend.append('description', formData.description);
       formDataToSend.append('features', JSON.stringify(formData.features.split(',').map(f => f.trim()).filter(f => f)));
       formDataToSend.append('specifications', JSON.stringify(specifications));

--- a/src/components/ProductList.tsx
+++ b/src/components/ProductList.tsx
@@ -259,7 +259,7 @@ interface Product {
   category: string;
   sport: string;
   price: number;
-  stock: number;
+  quantity: number;
   brand?: string;
   size?: string;
 }
@@ -426,8 +426,8 @@ const ProductList: React.FC = () => {
               <ProductCard key={product.id}>
                 <ProductHeader>
                   <ProductName>{product.name}</ProductName>
-                  <StockBadge lowStock={product.stock < 5}>
-                    {product.stock} in stock
+                  <StockBadge lowStock={product.quantity < 5}>
+                    {product.quantity} in stock
                   </StockBadge>
                 </ProductHeader>
                 


### PR DESCRIPTION
## Summary
- send `quantity` when adding products so inventory saves correctly
- update product list to read `quantity`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684cea199a988324b4600c90752f2b08